### PR TITLE
Feature/profile

### DIFF
--- a/Front/ChangaYa-App/app/_layout.tsx
+++ b/Front/ChangaYa-App/app/_layout.tsx
@@ -15,14 +15,20 @@ export default function RootLayout() {
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
-      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-      <Stack.Screen name="auth/welcome" options={{ headerShown: false }} />
-      <Stack.Screen name="auth/login" options={{ headerShown: false }}/>
-      <Stack.Screen name="auth/register" options={{ headerShown: false }}/>
-      <Stack.Screen name="home/trabajador" options={{ headerShown: false }} />
-      <Stack.Screen name="home/contratante" options={{ headerShown: false }} />
-      <Stack.Screen name="chats/index" options={{ headerShown: false }} />
-    </Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="auth/welcome" options={{ headerShown: false }} />
+        <Stack.Screen name="auth/login" options={{ headerShown: false }} />
+        <Stack.Screen name="auth/register" options={{ headerShown: false }} />
+        <Stack.Screen name="home/trabajador" options={{ headerShown: false }} />
+        <Stack.Screen name="home/contratante" options={{ headerShown: false }} />
+        <Stack.Screen name="chats/index" options={{ headerShown: false }} />
+        <Stack.Screen name="chats/[id]" options={{ headerShown: false }} />
+        <Stack.Screen name="changas/favoritas" options={{ headerShown: false }} />
+        <Stack.Screen name="changas/mis" options={{ headerShown: false }} />
+        <Stack.Screen name="changas/nueva" options={{ headerShown: false }} />
+        <Stack.Screen name="changas/[id]" options={{ headerShown: false }} />
+        <Stack.Screen name="modal" options={{ headerShown: false }} />
+      </Stack>
       <StatusBar style="auto" />
     </ThemeProvider>
   );

--- a/Front/ChangaYa-App/app/chats/[id].tsx
+++ b/Front/ChangaYa-App/app/chats/[id].tsx
@@ -14,6 +14,7 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
+import { useProfileNavigation } from '@/hooks/use-profile-navigation';
 
 // --- Datos de Ejemplo ---
 // (Reemplazar con tu lógica de Supabase)
@@ -21,8 +22,9 @@ import {
 // Simulamos los detalles del chat que abrimos
 // En la vida real, harías un fetch a Supabase usando el 'id'
 const DUMMY_CHAT_DETAILS = {
-    id: '1', 
-    user: 'Ana Martínez', 
+    id: '1',
+    userId: 'worker-002',
+    user: 'Ana Martínez',
     avatar: 'AM', // Podría ser una URL a una imagen
     online: true,
 };
@@ -104,6 +106,7 @@ const ChatScreen = () => {
     // 1. OBTENER EL ID DEL CHAT
     // 'useLocalSearchParams' lee los parámetros de la URL, en este caso, el '[id]'
     const { id } = useLocalSearchParams();
+    const { goToProfile } = useProfileNavigation();
     
     const [messages, setMessages] = useState<Message[]>([]);
     const [newMessage, setNewMessage] = useState('');
@@ -159,12 +162,12 @@ const ChatScreen = () => {
         >
             {/* 4. CONFIGURACIÓN DEL HEADER */}
             {/* Usamos Stack.Screen para configurar el header de esta ruta dinámica */}
-            <Stack.Screen 
+            <Stack.Screen
                 options={{
                     // Esto recrea el header de tu captura
                     headerTitle: () => (
                         <View style={styles.headerContainer}>
-                            <Image style={styles.headerAvatar} source={{ uri: 'https://via.placeholder.com/40' }} /> 
+                            <Image style={styles.headerAvatar} source={{ uri: 'https://via.placeholder.com/40' }} />
                             <View>
                                 <Text style={styles.headerTitle}>{DUMMY_CHAT_DETAILS.user}</Text>
                                 <Text style={styles.headerSubtitle}>En línea</Text>
@@ -172,9 +175,18 @@ const ChatScreen = () => {
                         </View>
                     ),
                     headerRight: () => (
-                        <TouchableOpacity style={{ marginRight: 15 }}>
-                            <Ionicons name="ellipsis-vertical" size={24} color="#333" />
-                        </TouchableOpacity>
+                        <View style={styles.headerActions}>
+                            <TouchableOpacity
+                                style={styles.headerIconButton}
+                                onPress={() => goToProfile(DUMMY_CHAT_DETAILS.userId)}
+                                accessibilityLabel="Ver perfil"
+                            >
+                                <Ionicons name="person-circle-outline" size={24} color="#333" />
+                            </TouchableOpacity>
+                            <TouchableOpacity style={styles.headerIconButton}>
+                                <Ionicons name="ellipsis-vertical" size={24} color="#333" />
+                            </TouchableOpacity>
+                        </View>
                     ),
                     headerBackTitle: '', // Esto pone un texto vacío en el botón 'Atrás' de iOS // Oculta el texto "Atrás" en iOS
                     headerShadowVisible: false, // Quita la sombra
@@ -247,6 +259,15 @@ const styles = StyleSheet.create({
     headerSubtitle: {
         fontSize: 13,
         color: '#555',
+    },
+    headerActions: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginRight: 15,
+        gap: 8,
+    },
+    headerIconButton: {
+        padding: 6,
     },
     // Lista de Mensajes
     messageList: {

--- a/Front/ChangaYa-App/app/chats/index.tsx
+++ b/Front/ChangaYa-App/app/chats/index.tsx
@@ -1,158 +1,137 @@
 // Front/ChangaYa-App/app/chats/index.tsx
 
 import { Ionicons } from '@expo/vector-icons';
-import { usePathname, useRouter, type Href } from 'expo-router'; // <-- MODIFICADO
+import { usePathname, useRouter, type Href } from 'expo-router';
 import React, { useState } from 'react';
 import {
-	FlatList,
-	SafeAreaView,
-	StyleSheet,
-	Text,
-	TextInput,
-	TouchableOpacity, // <-- AÑADIDO
-	View,
+  FlatList,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
 } from 'react-native';
 import ChatListItem, { Chat } from '../../components/ChatListItem';
-import theme from '../../constants/theme'; // <-- AÑADIDO
+import theme from '../../constants/theme';
+import { useProfileNavigation } from '../../hooks/use-profile-navigation'; // agregado
 
-// AÑADIDO: Constantes de Estilo (copiadas de trabajador.tsx)
 const { FONT, SPACING, RADIUS } = theme;
 const palette = theme.Colors.light;
 
-// Datos de ejemplo (Tus datos)
-// Aplicamos el tipo 'Chat[]' para asegurar que los datos coinciden
 const DUMMY_CHATS: Chat[] = [
-	{ id: '1', user: 'Ana Martínez', lastMessage: '¡Perfecto! Llego en 15 minutos', time: '10:30', unread: 2 },
-	{ id: '2', user: 'Carlos López', lastMessage: 'Gracias por la changa! Todo...', time: 'Ayer', unread: 0 },
+  {
+    id: '1',
+    user: 'Ana Martínez',
+    lastMessage: '¡Perfecto! Llego en 15 minutos',
+    time: '10:30',
+    unread: 2,
+  },
+  {
+    id: '2',
+    user: 'Carlos López',
+    lastMessage: 'Gracias por la changa! Todo...',
+    time: 'Ayer',
+    unread: 0,
+  },
 ];
 
-// AÑADIDO: Navegación (copiada de trabajador.tsx)
 const quickLinks: {
-	id: string;
-	title: string;
-	icon: keyof typeof Ionicons.glyphMap;
-	route: Href;
+  id: string;
+  title: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  route: Href;
 }[] = [
-	{ id: "home", title: "Home", icon: "home-outline" as const, route: "/home/trabajador" as Href },
-	{
-		id: "chats",
-		title: "Chats",
-		icon: "chatbubble-ellipses-outline" as const,
-		route: "/chats" as Href,
-	},
-	{
-		id: "mis-changas",
-		title: "Mis Changas",
-		icon: "briefcase-outline" as const,
-		route: "/changas" as Href,
-	},
-	{
-		id: "perfil",
-		title: "Perfil",
-		icon: "person-circle-outline" as const,
-		route: "/profile" as Href,
-	},
+  { id: 'home', title: 'Home', icon: 'home-outline', route: '/home/trabajador' as Href },
+  { id: 'chats', title: 'Chats', icon: 'chatbubble-ellipses-outline', route: '/chats' as Href },
+  { id: 'mis-changas', title: 'Mis Changas', icon: 'briefcase-outline', route: '/changas' as Href },
+  { id: 'perfil', title: 'Perfil', icon: 'person-circle-outline', route: '/perfil' as Href },
 ];
 
-// =========================================================
-// COMPONENTE DE PANTALLA
-// =========================================================
 const ChatsScreen = () => {
-	const router = useRouter();
-	const pathname = usePathname(); // <-- AÑADIDO
-	const [chats, setChats] = useState<Chat[]>(DUMMY_CHATS); // <-- Usamos Chat[]
-	const [searchText, setSearchText] = useState('');
+  const router = useRouter();
+  const pathname = usePathname();
+  const [chats] = useState<Chat[]>(DUMMY_CHATS);
+  const [searchText, setSearchText] = useState('');
+  const { goToProfile } = useProfileNavigation(); // nuevo hook
 
-	// ... Tu lógica de useEffect (comentada) ...
+  const handleChatPress = (chatId: string) => {
+    router.push({ pathname: '/chats/[id]', params: { id: chatId } });
+  };
 
-	const handleChatPress = (chatId: string) => {
-		router.push({ pathname: '/chats/[id]', params: { id: chatId } });
-	};
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.container}>
+        <View style={styles.contentWrapper}>
+          <Text style={styles.headerTitle}>Chats</Text>
 
-	return (
-		// MODIFICADO: Usamos la estructura de trabajador.tsx
-		<SafeAreaView style={styles.safeArea}>
-			<View style={styles.container}>
-				
-				{/* Contenido principal: Usamos un View flexible para que 
-					el contenido de la lista ocupe todo el espacio 
-					y la barra de navegación quede pegada abajo.
-				*/}
-				<View style={styles.contentWrapper}>
-					{/* Encabezado y Barra de Búsqueda */}
-					<Text style={styles.headerTitle}>Chats</Text>
-					<View style={styles.searchContainer}>
-						<Ionicons name="search" size={20} color={palette.muted} style={styles.searchIcon} />
-						<TextInput
-							style={styles.searchInput}
-							placeholder="Buscar conversaciones..."
-							placeholderTextColor={palette.muted} // <-- AÑADIDO
-							value={searchText}
-							onChangeText={setSearchText}
-						/>
-						<TouchableOpacity style={styles.editIconContainer}>
-							<Ionicons name="create-outline" size={24} color="#555" />
-						</TouchableOpacity>
-					</View>
+          <View style={styles.searchContainer}>
+            <Ionicons name="search" size={20} color={palette.muted} style={styles.searchIcon} />
+            <TextInput
+              style={styles.searchInput}
+              placeholder="Buscar conversaciones..."
+              placeholderTextColor={palette.muted}
+              value={searchText}
+              onChangeText={setSearchText}
+            />
+            <TouchableOpacity style={styles.editIconContainer}>
+              <Ionicons name="create-outline" size={24} color="#555" />
+            </TouchableOpacity>
+          </View>
 
-					{/* Lista de Conversaciones */}
-					<FlatList
-						data={chats.filter(chat => chat.user.toLowerCase().includes(searchText.toLowerCase()))}
-						keyExtractor={(item) => item.id}
-						renderItem={({ item }) => (
-							<ChatListItem
-								chat={item}
-								onPress={() => handleChatPress(item.id)}
-							/>
-						)}
-						ItemSeparatorComponent={() => <View style={styles.separator} />}
-					/>
-				</View>
+          <FlatList
+            data={chats.filter((chat) =>
+              chat.user.toLowerCase().includes(searchText.toLowerCase()),
+            )}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => (
+              <ChatListItem chat={item} onPress={() => handleChatPress(item.id)} />
+            )}
+            ItemSeparatorComponent={() => <View style={styles.separator} />}
+          />
+        </View>
 
-				{/* AÑADIDO: Barra de navegación (copiada de trabajador.tsx) */}
-				<View style={styles.bottomNav}>
-					{quickLinks.map((item) => {
-						const routePath =
-							typeof item.route === "string"
-								? item.route
-								: (item.route as any)?.pathname ?? String(item.route);
-						const isActive =
-							pathname === routePath || pathname.startsWith(`${routePath}/`);
-						return (
-							<TouchableOpacity
-								key={item.id}
-								style={[styles.navItem, isActive && styles.navItemActive]}
-								onPress={() => {
-                                // SI es el botón de Home...
-                                if (item.id === 'home') {
-                                    // ¡CAMBIO! Simplemente retrocedemos a la pantalla anterior
-                                    router.back(); 
-                                } 
-                                // PARA CUALQUIER OTRO BOTÓN...
-                                else {
-                                    // Usamos la ruta definida en quickLinks (comportamiento original)
-                                    router.push(item.route);
-                                }
-                            }}
-							>
-								<Ionicons
-									name={item.icon}
-									size={22}
-									color={isActive ? palette.tint : palette.icon}
-								/>
-								<Text style={[styles.navText, isActive && styles.navTextActive]}>
-									{item.title}
-								</Text>
-								{isActive ? <View style={styles.activeIndicator} /> : null}
-							</TouchableOpacity>
-						);
-					})}
-				</View>
-			</View>
-		</SafeAreaView>
-	);
+        <View style={styles.bottomNav}>
+          {quickLinks.map((item) => {
+            const routePath =
+              typeof item.route === 'string'
+                ? item.route
+                : (item.route as any)?.pathname ?? String(item.route);
+            const isActive = pathname === routePath || pathname.startsWith(`${routePath}/`);
+
+            return (
+              <TouchableOpacity
+                key={item.id}
+                style={[styles.navItem, isActive && styles.navItemActive]}
+                onPress={() => {
+                  if (item.id === 'perfil') {
+                    goToProfile();
+                    return;
+                  }
+                  if (item.id === 'home') {
+                    router.back();
+                  } else {
+                    router.push(item.route);
+                  }
+                }}
+              >
+                <Ionicons
+                  name={item.icon}
+                  size={22}
+                  color={isActive ? palette.tint : palette.icon}
+                />
+                <Text style={[styles.navText, isActive && styles.navTextActive]}>
+                  {item.title}
+                </Text>
+                {isActive ? <View style={styles.activeIndicator} /> : null}
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </View>
+    </SafeAreaView>
+  );
 };
-
 // =========================================================
 // ESTILOS
 // =========================================================

--- a/Front/ChangaYa-App/app/home/contratante.tsx
+++ b/Front/ChangaYa-App/app/home/contratante.tsx
@@ -24,7 +24,7 @@ import { HelloWave } from "../../components/hello-wave";
 
 import theme from "../../constants/theme";
 
-
+import { useProfileNavigation } from "../../hooks/use-profile-navigation";
 
 // CONSTANTES DEL TEMA
 
@@ -204,7 +204,7 @@ const quickLinks: {
 
     icon: "person-circle-outline" as const,
 
-    route: "/profile" as Href,
+    route: "/perfil" as Href,
 
   },
 
@@ -222,9 +222,11 @@ export default function InicioContratanteScreen() {
 
   const router = useRouter();
 
-  const pathname = usePathname(); 
+  const pathname = usePathname();
 
   const initials = useMemo(() => "María".charAt(0), []);
+
+  const { goToProfile } = useProfileNavigation();
 
 
 
@@ -602,19 +604,23 @@ export default function InicioContratanteScreen() {
                 style={[styles.navItem, isActive && styles.navItemActive]}
 
                   onPress={() => {
+                    if (item.id === 'perfil') {
+                        goToProfile();
+                        return;
+                    }
                     // SI es el botón de Chats...
                     if (item.id === 'chats') {
                         // Navegamos a /chats y enviamos la ruta de regreso
-                        router.push({ 
-                            pathname: '/chats', 
+                        router.push({
+                            pathname: '/chats',
                             params: { returnHome: '/home/contratante' } // <-- Parámetro clave
                         });
-                    } 
+                    }
                     // SI es el botón de Home...
                     else if (item.id === 'home') {
                         // ¡CAMBIO! Simplemente retrocedemos
-                        router.back(); 
-                    } 
+                        router.back();
+                    }
                     // PARA CUALQUIER OTRO BOTÓN...
                     else {
                         // Usamos la ruta definida en quickLinks

--- a/Front/ChangaYa-App/app/home/trabajador.tsx
+++ b/Front/ChangaYa-App/app/home/trabajador.tsx
@@ -13,7 +13,7 @@ import {
 
 import { HelloWave } from "../../components/hello-wave";
 import theme from "../../constants/theme";
-
+import { useProfileNavigation } from "../../hooks/use-profile-navigation";
 const { FONT, SPACING, RADIUS } = theme;
 const palette = theme.Colors.light;
 
@@ -83,14 +83,28 @@ const quickLinks: {
     id: "perfil",
     title: "Perfil",
     icon: "person-circle-outline" as const,
-    route: "/profile" as Href,
+    route: "/perfil" as Href,
   },
 ];
 export default function InicioTrabajadorScreen() {
   const router = useRouter();
   const pathname = usePathname();
-  const initials = useMemo(() => "Juan".charAt(0), []);
+  
   const [searchQuery, setSearchQuery] = useState("");
+  
+  
+  const { goToProfile, currentUser } = useProfileNavigation();
+
+  // Calculamos iniciales desde el nombre real (ej. María Rodríguez)
+  const initials = useMemo(() => {
+  if (!currentUser?.name) return "?";
+  return currentUser.name
+    .split(" ")
+    .slice(0, 2)
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase();
+}, [currentUser?.name]);
 
   return (
     <SafeAreaView style={styles.safeArea}>
@@ -100,20 +114,23 @@ export default function InicioTrabajadorScreen() {
           contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
         >
-          {/* Header */}
-          <View style={styles.header}>
-            <View style={styles.headerText}>
-              <View style={styles.greetingRow}>
-                <Text style={styles.greeting}>¡Hola Juan!</Text>
-                <HelloWave />
-              </View>
-              <Text style={styles.subtitle}>Encuentra tu próxima changa</Text>
-            </View>
+        <View style={styles.header}>
+          <View style={styles.headerText}>
+            <View style={styles.greetingRow}>
+              <Text style={styles.greeting}>¡Hola {currentUser.name.split(" ")[0]}!
+              </Text>
+                 <HelloWave />
+        </View>
+    <Text style={styles.subtitle}>Encuentra tu próxima changa</Text>
+  </View>
 
-            <View style={styles.avatar}>
-              <Text style={styles.avatarInitial}>{initials}</Text>
-            </View>
-          </View>
+  <TouchableOpacity
+    style={styles.avatar}
+    onPress={() => goToProfile(currentUser.id)} // Tocar avatar abre el perfil
+  >
+    <Text style={styles.avatarInitial}>{initials}</Text>
+  </TouchableOpacity>
+</View>
 
           {/* Barra de búsqueda */}
           <View style={styles.searchWrapper}>
@@ -229,7 +246,14 @@ export default function InicioTrabajadorScreen() {
               <TouchableOpacity
                 key={item.id}
                 style={[styles.navItem, isActive && styles.navItemActive]}
-                onPress={() => router.push(item.route)}
+                onPress={() => {
+                  if (item.id === "perfil") {
+                    goToProfile();
+                    return;
+                  }
+
+                  router.push(item.route);
+                }}
               >
               
                 <Ionicons

--- a/Front/ChangaYa-App/app/profile/[id].tsx
+++ b/Front/ChangaYa-App/app/profile/[id].tsx
@@ -35,7 +35,7 @@ type PublicProfile = {
 
 const MOCK_PROFILES: PublicProfile[] = [
   {
-    id: "1",
+    id: "worker-001",
     name: "María Rodríguez",
     location: "La Plata, Buenos Aires",
     rating: 4.8,
@@ -77,6 +77,77 @@ const MOCK_PROFILES: PublicProfile[] = [
         rating: 4.8,
         description:
           "Realizó varias reparaciones pequeñas y dejó todo funcionando perfecto. Muy recomendable.",
+      },
+    ],
+  },
+   {
+    id: "worker-002",
+    name: "Ana Martínez",
+    location: "Quilmes, Buenos Aires",
+    rating: 4.6,
+    completedJobs: 88,
+    generalScore: 0.89,
+    about:
+      "Electricista matriculada con foco en instalaciones domiciliarias seguras y eficientes. Disfruto acompañar al cliente en cada paso para que entienda qué estoy haciendo en su hogar.",
+    topSkills: [
+      { id: "skill-electrica", label: "Instalaciones eléctricas", level: 0.92, color: "#6BA368" },
+      { id: "skill-domotica", label: "Automatización hogareña", level: 0.82, color: "#A1E99D" },
+      { id: "skill-seguridad", label: "Seguridad eléctrica", level: 0.9, color: "#90C99F" },
+      { id: "skill-diagnostico", label: "Diagnóstico rápido", level: 0.85, color: "#CFE6CD" },
+    ],
+    reviews: [
+      {
+        id: "review-ana-1",
+        title: "Instalación de lámparas inteligentes",
+        contractor: "Marina Suárez",
+        date: "5 de febrero 2024",
+        rating: 4.8,
+        description:
+          "Ana explicó cada paso con mucha claridad y dejó todo funcionando perfecto. Super recomendada.",
+      },
+      {
+        id: "review-ana-2",
+        title: "Revisión tablero eléctrico",
+        contractor: "Diego Ramos",
+        date: "21 de enero 2024",
+        rating: 4.5,
+        description:
+          "Detectó un problema que otros técnicos no habían visto y lo resolvió al instante.",
+      },
+    ],
+  },
+  {
+    id: "contractor-123",
+    name: "Carlos Pérez",
+    location: "City Bell, Buenos Aires",
+    rating: 4.7,
+    completedJobs: 58,
+    generalScore: 0.88,
+    about:
+      "Contratante habitual de ChangaYa. Me enfoco en mantener relaciones de trabajo justas, pagar a tiempo y dejar reseñas detalladas para ayudar a otros trabajadores.",
+    topSkills: [
+      { id: "skill-planificacion", label: "Planificación", level: 0.84, color: "#6BA368" },
+      { id: "skill-comunicacion", label: "Comunicación", level: 0.88, color: "#A1E99D" },
+      { id: "skill-negociacion", label: "Negociación", level: 0.8, color: "#90C99F" },
+    ],
+    reviews: [
+      {
+        id: "review-carlos-1",
+        title: "Instalación de cortinas",
+        contractor: "María Rodríguez",
+        date: "8 de marzo 2024",
+        rating: 4.9,
+        description:
+          "Carlos fue claro con los requerimientos y pagó al instante. Excelente experiencia como contratante.",
+      },
+      {
+        id: "review-carlos-2",
+        title: "Pintura interior",
+        contractor: "Ana Martínez",
+        date: "30 de enero 2024",
+        rating: 4.6,
+        description:
+          "Muy organizado y respetuoso. Coordinamos horarios sin problema y la comunicación fue excelente.",
       },
     ],
   },

--- a/Front/ChangaYa-App/app/profile/[id].tsx
+++ b/Front/ChangaYa-App/app/profile/[id].tsx
@@ -1,0 +1,266 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Stack, useLocalSearchParams } from "expo-router";
+import {
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+
+import ProfileHeader from "../../components/profile/ProfileHeader";
+import SkillsList, {
+  type SkillItem,
+} from "../../components/profile/SkillsList";
+import ReviewItem, {
+  type ReviewItemProps,
+} from "../../components/profile/ReviewItem";
+import theme from "../../constants/theme";
+
+const { FONT, SPACING, RADIUS } = theme;
+const palette = theme.Colors.light;
+const fontFamilies = theme.Fonts;
+
+type PublicProfile = {
+  id: string;
+  name: string;
+  location: string;
+  rating: number;
+  completedJobs: number;
+  generalScore: number;
+  about: string;
+  topSkills: SkillItem[];
+  reviews: ReviewItemProps[];
+};
+
+const MOCK_PROFILES: PublicProfile[] = [
+  {
+    id: "1",
+    name: "María Rodríguez",
+    location: "La Plata, Buenos Aires",
+    rating: 4.8,
+    completedJobs: 132,
+    generalScore: 0.92,
+    about:
+      "Plomera certificada con más de 6 años de experiencia. Me especializo en reparaciones urgentes, instalaciones nuevas y mantenimiento preventivo. Me encanta trabajar de manera prolija y mantener informado al cliente durante cada etapa.",
+    topSkills: [
+      { id: "skill-plomeria", label: "Plomería", level: 0.97, color: "#6BA368" },
+      { id: "skill-gas", label: "Instalaciones de gas", level: 0.9, color: "#A1E99D" },
+      { id: "skill-electricidad", label: "Electricidad", level: 0.86, color: "#CFE6CD" },
+      { id: "skill-pintura", label: "Pintura", level: 0.78, color: "#90C99F" },
+      { id: "skill-mantenimiento", label: "Mantenimiento general", level: 0.74, color: "#B7E4C7" },
+    ],
+    reviews: [
+      {
+        id: "review-1",
+        title: "Reparación de caño en cocina",
+        contractor: "Carlos Pérez",
+        date: "12 de marzo 2024",
+        rating: 4.9,
+        description:
+          "María llegó en menos de una hora y solucionó el problema sin inconvenientes. Además dejó todo impecable y me explicó cómo evitar que vuelva a suceder.",
+      },
+      {
+        id: "review-2",
+        title: "Instalación de termotanque",
+        contractor: "Lorena Díaz",
+        date: "28 de febrero 2024",
+        rating: 4.7,
+        description:
+          "Excelente trabajo, muy cuidadosa con los detalles y cumplió con los tiempos acordados.",
+      },
+      {
+        id: "review-3",
+        title: "Mantenimiento general del baño",
+        contractor: "Javier Gómez",
+        date: "18 de enero 2024",
+        rating: 4.8,
+        description:
+          "Realizó varias reparaciones pequeñas y dejó todo funcionando perfecto. Muy recomendable.",
+      },
+    ],
+  },
+];
+
+const PerfilPublicoScreen = () => {
+  const { id } = useLocalSearchParams<{ id?: string }>();
+  const profile =
+    MOCK_PROFILES.find((item) => item.id === id) ?? MOCK_PROFILES[0];
+  const initials = profile.name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part.charAt(0))
+    .join("")
+    .toUpperCase();
+  const generalScorePercent = Math.round(
+    Math.min(1, Math.max(0, profile.generalScore)) * 100,
+  );
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <Stack.Screen
+        options={{
+          title: profile.name,
+          headerTitleAlign: "center",
+          headerShadowVisible: false,
+        }}
+      />
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        <ProfileHeader
+          name={profile.name}
+          location={profile.location}
+          rating={profile.rating}
+          completedJobs={profile.completedJobs}
+          avatarInitials={initials}
+          actions={[
+            {
+              label: "Mensaje",
+              icon: "chatbubble-ellipses-outline",
+              variant: "secondary",
+            },
+            {
+              label: "Contratar",
+              icon: "briefcase-outline",
+              variant: "primary",
+            },
+          ]}
+        />
+
+        <View style={styles.sectionCard}>
+          <View style={styles.sectionHeaderRow}>
+            <Text style={styles.sectionTitle}>Puntuación general</Text>
+            <Text style={styles.sectionValue}>
+              {generalScorePercent}%
+            </Text>
+          </View>
+          <View style={styles.progressTrack}>
+            <View
+              style={[
+                styles.progressFill,
+                { width: `${generalScorePercent}%` },
+              ]}
+            />
+          </View>
+          <Text style={styles.sectionHint}>
+            Basado en {profile.completedJobs} changas completadas.
+          </Text>
+        </View>
+
+        <SkillsList title="Top 5 habilidades" skills={profile.topSkills} />
+
+        <View style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>Sobre mí</Text>
+          <Text style={styles.bodyText}>{profile.about}</Text>
+        </View>
+
+        <View style={styles.sectionCard}>
+          <View style={styles.sectionHeaderRow}>
+            <Text style={styles.sectionTitle}>Changas realizadas</Text>
+            <View style={styles.reviewsBadge}>
+              <Ionicons name="medal-outline" size={16} color={palette.tint} />
+              <Text style={styles.reviewsBadgeText}>
+                {profile.reviews.length} reseñas recientes
+              </Text>
+            </View>
+          </View>
+          <View style={styles.reviewList}>
+            {profile.reviews.map((review) => (
+              <ReviewItem key={review.id} {...review} />
+            ))}
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: palette.background,
+  },
+  scroll: {
+    flex: 1,
+  },
+  content: {
+    padding: SPACING.lg,
+    gap: SPACING.lg,
+    paddingBottom: SPACING.lg * 2,
+  },
+  sectionCard: {
+    backgroundColor: palette.white,
+    borderRadius: RADIUS.lg,
+    padding: SPACING.lg,
+    gap: SPACING.sm,
+    shadowColor: "#000",
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 10 },
+    shadowRadius: 18,
+    elevation: 4,
+  },
+  sectionHeaderRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: SPACING.sm,
+  },
+  sectionTitle: {
+    fontSize: FONT.lg,
+    color: palette.text,
+    fontWeight: "700",
+    fontFamily: fontFamilies.rounded,
+  },
+  sectionValue: {
+    fontSize: FONT.lg,
+    color: palette.tint,
+    fontWeight: "700",
+    fontFamily: fontFamilies.rounded,
+  },
+  progressTrack: {
+    height: 12,
+    backgroundColor: palette.background,
+    borderRadius: 999,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    backgroundColor: palette.tint,
+    borderRadius: 999,
+  },
+  sectionHint: {
+    fontSize: FONT.sm,
+    color: palette.muted,
+    fontFamily: fontFamilies.rounded,
+  },
+  bodyText: {
+    fontSize: FONT.md,
+    lineHeight: 22,
+    color: palette.text,
+    fontFamily: fontFamilies.rounded,
+  },
+  reviewList: {
+    gap: SPACING.md,
+  },
+  reviewsBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: palette.background,
+    borderRadius: RADIUS.md,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+    gap: 6,
+  },
+  reviewsBadgeText: {
+    fontSize: FONT.sm,
+    color: palette.tint,
+    fontFamily: fontFamilies.rounded,
+    fontWeight: "600",
+  },
+});
+
+export default PerfilPublicoScreen;

--- a/Front/ChangaYa-App/app/profile/index.tsx
+++ b/Front/ChangaYa-App/app/profile/index.tsx
@@ -1,3 +1,5 @@
+// Front/ChangaYa-App/app/perfil/index.tsx
+
 import { Ionicons } from "@expo/vector-icons";
 import { Stack } from "expo-router";
 import {
@@ -13,12 +15,14 @@ import ProfileHeader from "../../components/profile/ProfileHeader";
 import SkillsList from "../../components/profile/SkillsList";
 import ReviewItem from "../../components/profile/ReviewItem";
 import theme from "../../constants/theme";
+import { useProfileNavigation } from "@/hooks/use-profile-navigation"; // añadido
 
 const { FONT, SPACING, RADIUS } = theme;
 const palette = theme.Colors.light;
 const fontFamilies = theme.Fonts;
 
 const USER_PROFILE = {
+  id: "worker-001", // añadido para coherencia con los perfiles públicos mockeados
   name: "María Rodríguez",
   location: "La Plata, Buenos Aires",
   rating: 4.8,
@@ -71,9 +75,12 @@ const PerfilPrivadoScreen = () => {
     .map((part) => part.charAt(0))
     .join("")
     .toUpperCase();
+
   const generalScorePercent = Math.round(
-    Math.min(1, Math.max(0, USER_PROFILE.generalScore)) * 100,
+    Math.min(1, Math.max(0, USER_PROFILE.generalScore)) * 100
   );
+
+  const { currentUserId } = useProfileNavigation(); // coherencia futura con navegación centralizada
 
   return (
     <SafeAreaView style={styles.safeArea}>
@@ -101,9 +108,7 @@ const PerfilPrivadoScreen = () => {
         <View style={styles.sectionCard}>
           <View style={styles.sectionHeaderRow}>
             <Text style={styles.sectionTitle}>Puntuación general</Text>
-            <Text style={styles.sectionValue}>
-              {generalScorePercent}%
-            </Text>
+            <Text style={styles.sectionValue}>{generalScorePercent}%</Text>
           </View>
           <View style={styles.progressTrack}>
             <View

--- a/Front/ChangaYa-App/app/profile/index.tsx
+++ b/Front/ChangaYa-App/app/profile/index.tsx
@@ -1,0 +1,257 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Stack } from "expo-router";
+import {
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+import ProfileHeader from "../../components/profile/ProfileHeader";
+import SkillsList from "../../components/profile/SkillsList";
+import ReviewItem from "../../components/profile/ReviewItem";
+import theme from "../../constants/theme";
+
+const { FONT, SPACING, RADIUS } = theme;
+const palette = theme.Colors.light;
+const fontFamilies = theme.Fonts;
+
+const USER_PROFILE = {
+  name: "María Rodríguez",
+  location: "La Plata, Buenos Aires",
+  rating: 4.8,
+  completedJobs: 132,
+  generalScore: 0.92,
+  about:
+    "Amante de las soluciones prácticas y prolijas. Busco que cada cliente sienta tranquilidad sabiendo que su hogar está en buenas manos.",
+  topSkills: [
+    { id: "skill-plomeria", label: "Plomería", level: 0.97, color: "#6BA368" },
+    { id: "skill-gas", label: "Instalaciones de gas", level: 0.9, color: "#A1E99D" },
+    { id: "skill-electricidad", label: "Electricidad", level: 0.86, color: "#CFE6CD" },
+    { id: "skill-pintura", label: "Pintura", level: 0.78, color: "#90C99F" },
+    { id: "skill-mantenimiento", label: "Mantenimiento general", level: 0.74, color: "#B7E4C7" },
+  ],
+  reviews: [
+    {
+      id: "review-1",
+      title: "Reparación de caño en cocina",
+      contractor: "Carlos Pérez",
+      date: "12 de marzo 2024",
+      rating: 4.9,
+      description:
+        "María llegó en menos de una hora y solucionó el problema sin inconvenientes. Además dejó todo impecable y me explicó cómo evitar que vuelva a suceder.",
+    },
+    {
+      id: "review-2",
+      title: "Instalación de termotanque",
+      contractor: "Lorena Díaz",
+      date: "28 de febrero 2024",
+      rating: 4.7,
+      description:
+        "Excelente trabajo, muy cuidadosa con los detalles y cumplió con los tiempos acordados.",
+    },
+  ],
+};
+
+const ACCOUNT_OPTIONS = [
+  { id: "favorites", label: "Favoritas", icon: "heart-outline" },
+  { id: "history", label: "Historial", icon: "time-outline" },
+  { id: "payments", label: "Métodos de pago", icon: "card-outline" },
+  { id: "notifications", label: "Notificaciones", icon: "notifications-outline" },
+  { id: "logout", label: "Cerrar sesión", icon: "log-out-outline" },
+] as const;
+
+const PerfilPrivadoScreen = () => {
+  const initials = USER_PROFILE.name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part.charAt(0))
+    .join("")
+    .toUpperCase();
+  const generalScorePercent = Math.round(
+    Math.min(1, Math.max(0, USER_PROFILE.generalScore)) * 100,
+  );
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <Stack.Screen
+        options={{
+          title: "Mi Perfil",
+          headerTitleAlign: "center",
+          headerShadowVisible: false,
+        }}
+      />
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        <ProfileHeader
+          name={USER_PROFILE.name}
+          location={USER_PROFILE.location}
+          rating={USER_PROFILE.rating}
+          completedJobs={USER_PROFILE.completedJobs}
+          avatarInitials={initials}
+          showSettings
+        />
+
+        <View style={styles.sectionCard}>
+          <View style={styles.sectionHeaderRow}>
+            <Text style={styles.sectionTitle}>Puntuación general</Text>
+            <Text style={styles.sectionValue}>
+              {generalScorePercent}%
+            </Text>
+          </View>
+          <View style={styles.progressTrack}>
+            <View
+              style={[
+                styles.progressFill,
+                { width: `${generalScorePercent}%` },
+              ]}
+            />
+          </View>
+          <Text style={styles.sectionHint}>
+            Tu promedio se actualiza con cada changa completada.
+          </Text>
+        </View>
+
+        <SkillsList title="Top 5 habilidades" skills={USER_PROFILE.topSkills} />
+
+        <View style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>Sobre mí</Text>
+          <Text style={styles.bodyText}>{USER_PROFILE.about}</Text>
+        </View>
+
+        <View style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>Changas realizadas recientemente</Text>
+          <View style={styles.reviewList}>
+            {USER_PROFILE.reviews.map((review) => (
+              <ReviewItem key={review.id} {...review} />
+            ))}
+          </View>
+        </View>
+
+        <View style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>Opciones</Text>
+          <View style={styles.optionsList}>
+            {ACCOUNT_OPTIONS.map((option) => (
+              <TouchableOpacity key={option.id} style={styles.optionItem}>
+                <View style={styles.optionIconWrapper}>
+                  <Ionicons name={option.icon} size={20} color={palette.tint} />
+                </View>
+                <Text style={styles.optionLabel}>{option.label}</Text>
+                <Ionicons name="chevron-forward" size={18} color={palette.muted} />
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: palette.background,
+  },
+  scroll: {
+    flex: 1,
+  },
+  content: {
+    padding: SPACING.lg,
+    gap: SPACING.lg,
+    paddingBottom: SPACING.lg * 2,
+  },
+  sectionCard: {
+    backgroundColor: palette.white,
+    borderRadius: RADIUS.lg,
+    padding: SPACING.lg,
+    gap: SPACING.sm,
+    shadowColor: "#000",
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 10 },
+    shadowRadius: 18,
+    elevation: 4,
+  },
+  sectionHeaderRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: SPACING.sm,
+  },
+  sectionTitle: {
+    fontSize: FONT.lg,
+    color: palette.text,
+    fontWeight: "700",
+    fontFamily: fontFamilies.rounded,
+  },
+  sectionValue: {
+    fontSize: FONT.lg,
+    color: palette.tint,
+    fontWeight: "700",
+    fontFamily: fontFamilies.rounded,
+  },
+  progressTrack: {
+    height: 12,
+    backgroundColor: palette.background,
+    borderRadius: 999,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    backgroundColor: palette.tint,
+    borderRadius: 999,
+  },
+  sectionHint: {
+    fontSize: FONT.sm,
+    color: palette.muted,
+    fontFamily: fontFamilies.rounded,
+  },
+  bodyText: {
+    fontSize: FONT.md,
+    lineHeight: 22,
+    color: palette.text,
+    fontFamily: fontFamilies.rounded,
+  },
+  reviewList: {
+    gap: SPACING.md,
+  },
+  optionsList: {
+    gap: SPACING.sm,
+  },
+  optionItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.sm,
+    borderRadius: RADIUS.md,
+    backgroundColor: palette.background,
+    gap: SPACING.md,
+  },
+  optionIconWrapper: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: palette.white,
+    shadowColor: "#000",
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 4 },
+    shadowRadius: 8,
+    elevation: 2,
+  },
+  optionLabel: {
+    flex: 1,
+    fontSize: FONT.md,
+    color: palette.text,
+    fontFamily: fontFamilies.rounded,
+  },
+});
+
+export default PerfilPrivadoScreen;
+

--- a/Front/ChangaYa-App/components/profile/ProfileHeader.tsx
+++ b/Front/ChangaYa-App/components/profile/ProfileHeader.tsx
@@ -1,0 +1,270 @@
+import { Ionicons } from "@expo/vector-icons";
+import type { ReactNode } from "react";
+import {
+  StyleProp,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from "react-native";
+
+import theme from "../../constants/theme";
+
+const { FONT, SPACING, RADIUS } = theme;
+const palette = theme.Colors.light;
+const fontFamilies = theme.Fonts;
+
+type ActionVariant = "primary" | "secondary";
+
+export interface ProfileHeaderAction {
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  onPress?: () => void;
+  variant?: ActionVariant;
+  rightAdornment?: ReactNode;
+}
+
+interface ProfileHeaderProps {
+  name: string;
+  location: string;
+  rating: number;
+  completedJobs?: number;
+  avatarInitials: string;
+  actions?: ProfileHeaderAction[];
+  showSettings?: boolean;
+  onSettingsPress?: () => void;
+  style?: StyleProp<ViewStyle>;
+}
+
+const ProfileHeader = ({
+  name,
+  location,
+  rating,
+  completedJobs,
+  avatarInitials,
+  actions,
+  showSettings,
+  onSettingsPress,
+  style,
+}: ProfileHeaderProps) => {
+  return (
+    <View style={[styles.card, style]}>
+      <View style={styles.topRow}>
+        <View style={styles.avatarWrapper}>
+          <View style={styles.avatar}>
+            <Text style={styles.avatarInitials}>{avatarInitials}</Text>
+          </View>
+          <View style={styles.info}>
+            <Text style={styles.name}>{name}</Text>
+            <View style={styles.locationRow}>
+              <Ionicons
+                name="location-outline"
+                size={16}
+                color={palette.muted}
+                style={styles.locationIcon}
+              />
+              <Text style={styles.locationText}>{location}</Text>
+            </View>
+            <View style={styles.metaRow}>
+              <View style={styles.ratingBadge}>
+                <Ionicons
+                  name="star"
+                  size={14}
+                  color={palette.white}
+                  style={styles.ratingIcon}
+                />
+                <Text style={styles.ratingText}>{rating.toFixed(1)}</Text>
+              </View>
+              {typeof completedJobs === "number" && (
+                <Text style={styles.metaText}>
+                  {completedJobs} changas completadas
+                </Text>
+              )}
+            </View>
+          </View>
+        </View>
+        {showSettings ? (
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessibilityLabel="Abrir ajustes del perfil"
+            style={styles.settingsButton}
+            onPress={onSettingsPress}
+            activeOpacity={0.85}
+          >
+            <Ionicons name="settings-outline" size={22} color={palette.tint} />
+          </TouchableOpacity>
+        ) : null}
+      </View>
+
+      {actions && actions.length > 0 ? (
+        <View style={styles.actionsRow}>
+          {actions.map((action) => (
+            <TouchableOpacity
+              key={action.label}
+              style={[
+                styles.actionButton,
+                action.variant === "secondary"
+                  ? styles.actionButtonSecondary
+                  : styles.actionButtonPrimary,
+              ]}
+              onPress={action.onPress}
+              activeOpacity={0.85}
+            >
+              <Ionicons
+                name={action.icon}
+                size={18}
+                color={
+                  action.variant === "secondary" ? palette.tint : palette.white
+                }
+                style={styles.actionIcon}
+              />
+              <Text
+                style={[
+                  styles.actionLabel,
+                  action.variant === "secondary" && styles.actionLabelSecondary,
+                ]}
+              >
+                {action.label}
+              </Text>
+              {action.rightAdornment}
+            </TouchableOpacity>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: palette.white,
+    borderRadius: RADIUS.lg,
+    padding: SPACING.lg,
+    shadowColor: "#000",
+    shadowOpacity: 0.06,
+    shadowOffset: { width: 0, height: 8 },
+    shadowRadius: 16,
+    elevation: 3,
+    gap: SPACING.md,
+  },
+  topRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+  },
+  avatarWrapper: {
+    flexDirection: "row",
+    flex: 1,
+    gap: SPACING.md,
+  },
+  avatar: {
+    width: 68,
+    height: 68,
+    borderRadius: 34,
+    backgroundColor: palette.tint,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  avatarInitials: {
+    color: palette.white,
+    fontSize: FONT.xl,
+    fontWeight: "700",
+    fontFamily: fontFamilies.rounded,
+  },
+  info: {
+    flex: 1,
+  },
+  name: {
+    fontSize: FONT.xxl,
+    fontWeight: "700",
+    color: palette.text,
+    fontFamily: fontFamilies.rounded,
+    marginBottom: SPACING.xs,
+  },
+  locationRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: SPACING.xs,
+  },
+  locationIcon: {
+    marginRight: SPACING.xs,
+  },
+  locationText: {
+    color: palette.muted,
+    fontSize: FONT.md,
+    fontFamily: fontFamilies.rounded,
+  },
+  metaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: SPACING.sm,
+  },
+  ratingBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: palette.tint,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+    borderRadius: RADIUS.md,
+  },
+  ratingIcon: {
+    marginRight: 4,
+  },
+  ratingText: {
+    color: palette.white,
+    fontFamily: fontFamilies.rounded,
+    fontSize: FONT.md,
+    fontWeight: "600",
+  },
+  metaText: {
+    fontSize: FONT.sm,
+    color: palette.muted,
+    fontFamily: fontFamilies.rounded,
+  },
+  settingsButton: {
+    width: 42,
+    height: 42,
+    borderRadius: 21,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: palette.background,
+    borderWidth: 1,
+    borderColor: palette.border,
+  },
+  actionsRow: {
+    flexDirection: "row",
+    gap: SPACING.sm,
+  },
+  actionButton: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: SPACING.sm,
+    borderRadius: RADIUS.md,
+  },
+  actionButtonPrimary: {
+    backgroundColor: palette.tint,
+  },
+  actionButtonSecondary: {
+    backgroundColor: palette.white,
+    borderWidth: 1,
+    borderColor: palette.border,
+  },
+  actionIcon: {
+    marginRight: SPACING.xs,
+  },
+  actionLabel: {
+    fontSize: FONT.md,
+    color: palette.white,
+    fontFamily: fontFamilies.rounded,
+    fontWeight: "600",
+  },
+  actionLabelSecondary: {
+    color: palette.tint,
+  },
+});
+
+export default ProfileHeader;

--- a/Front/ChangaYa-App/components/profile/ReviewItem.tsx
+++ b/Front/ChangaYa-App/components/profile/ReviewItem.tsx
@@ -1,0 +1,98 @@
+import { Ionicons } from "@expo/vector-icons";
+import { StyleSheet, Text, View } from "react-native";
+
+import theme from "../../constants/theme";
+
+const { FONT, SPACING, RADIUS } = theme;
+const palette = theme.Colors.light;
+const fontFamilies = theme.Fonts;
+
+export interface ReviewItemProps {
+  id: string;
+  title: string;
+  contractor: string;
+  date: string;
+  rating: number;
+  description?: string;
+}
+
+const ReviewItem = ({ title, contractor, date, rating, description }: ReviewItemProps) => {
+  return (
+    <View style={styles.card}>
+      <View style={styles.headerRow}>
+        <View style={styles.titleBlock}>
+          <Text style={styles.title}>{title}</Text>
+          <Text style={styles.subtitle}>{contractor}</Text>
+        </View>
+        <View style={styles.ratingBadge}>
+          <Ionicons name="star" size={16} color={palette.white} />
+          <Text style={styles.ratingText}>{rating.toFixed(1)}</Text>
+        </View>
+      </View>
+      <Text style={styles.dateLabel}>{date}</Text>
+      {description ? <Text style={styles.description}>{description}</Text> : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: palette.white,
+    borderRadius: RADIUS.md,
+    padding: SPACING.md,
+    gap: SPACING.xs,
+    shadowColor: "#000",
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 6 },
+    shadowRadius: 14,
+    elevation: 3,
+  },
+  headerRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  titleBlock: {
+    flex: 1,
+    marginRight: SPACING.sm,
+    gap: 2,
+  },
+  title: {
+    fontSize: FONT.lg,
+    color: palette.text,
+    fontWeight: "700",
+    fontFamily: fontFamilies.rounded,
+  },
+  subtitle: {
+    fontSize: FONT.sm,
+    color: palette.muted,
+    fontFamily: fontFamilies.rounded,
+  },
+  ratingBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: palette.tint,
+    borderRadius: RADIUS.sm,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+  },
+  ratingText: {
+    color: palette.white,
+    marginLeft: 4,
+    fontWeight: "600",
+    fontFamily: fontFamilies.rounded,
+  },
+  dateLabel: {
+    fontSize: FONT.sm,
+    color: palette.muted,
+    fontFamily: fontFamilies.rounded,
+  },
+  description: {
+    fontSize: FONT.md,
+    color: palette.text,
+    fontFamily: fontFamilies.rounded,
+    lineHeight: 20,
+  },
+});
+
+export default ReviewItem;

--- a/Front/ChangaYa-App/components/profile/SkillsList.tsx
+++ b/Front/ChangaYa-App/components/profile/SkillsList.tsx
@@ -1,0 +1,106 @@
+import { StyleSheet, Text, View } from "react-native";
+
+import theme from "../../constants/theme";
+
+const { FONT, SPACING, RADIUS } = theme;
+const palette = theme.Colors.light;
+const fontFamilies = theme.Fonts;
+
+export interface SkillItem {
+  id: string;
+  label: string;
+  level: number; // value between 0 and 1
+  color?: string;
+}
+
+interface SkillsListProps {
+  title?: string;
+  skills: SkillItem[];
+}
+
+const SkillsList = ({ title, skills }: SkillsListProps) => {
+  return (
+    <View style={styles.section}>
+      {title ? <Text style={styles.sectionTitle}>{title}</Text> : null}
+      <View style={styles.list}>
+        {skills.map((skill) => {
+          const percentage = Math.round(skill.level * 100);
+          return (
+            <View key={skill.id} style={styles.skillCard}>
+              <View style={styles.skillHeader}>
+                <Text style={styles.skillLabel}>{skill.label}</Text>
+                <Text style={styles.skillValue}>{percentage}%</Text>
+              </View>
+              <View style={styles.progressTrack}>
+                <View
+                  style={[
+                    styles.progressFill,
+                    {
+                      width: `${Math.min(100, Math.max(0, percentage))}%`,
+                      backgroundColor: skill.color ?? palette.tint,
+                    },
+                  ]}
+                />
+              </View>
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  section: {
+    gap: SPACING.sm,
+  },
+  sectionTitle: {
+    fontSize: FONT.lg,
+    fontWeight: "700",
+    color: palette.text,
+    fontFamily: fontFamilies.rounded,
+  },
+  list: {
+    gap: SPACING.sm,
+  },
+  skillCard: {
+    backgroundColor: palette.white,
+    borderRadius: RADIUS.md,
+    paddingVertical: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    shadowColor: "#000",
+    shadowOpacity: 0.04,
+    shadowOffset: { width: 0, height: 4 },
+    shadowRadius: 12,
+    elevation: 2,
+  },
+  skillHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: SPACING.xs,
+  },
+  skillLabel: {
+    fontSize: FONT.md,
+    color: palette.text,
+    fontFamily: fontFamilies.rounded,
+    fontWeight: "600",
+  },
+  skillValue: {
+    fontSize: FONT.sm,
+    color: palette.muted,
+    fontFamily: fontFamilies.rounded,
+  },
+  progressTrack: {
+    height: 8,
+    borderRadius: 999,
+    backgroundColor: palette.background,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    borderRadius: 999,
+  },
+});
+
+export default SkillsList;

--- a/Front/ChangaYa-App/constants/mock-auth.ts
+++ b/Front/ChangaYa-App/constants/mock-auth.ts
@@ -1,0 +1,13 @@
+export type MockUserRole = 'trabajador' | 'contratante';
+
+export type MockUser = {
+  id: string;
+  role: MockUserRole;
+  name: string;
+};
+
+export const MOCK_CURRENT_USER: MockUser = {
+  id: 'worker-001',
+  role: 'trabajador',
+  name: 'María Rodríguez',
+};

--- a/Front/ChangaYa-App/hooks/use-profile-navigation.ts
+++ b/Front/ChangaYa-App/hooks/use-profile-navigation.ts
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+import { useRouter } from 'expo-router';
+
+import { MOCK_CURRENT_USER } from '@/constants/mock-auth';
+
+export const useProfileNavigation = () => {
+  const router = useRouter();
+
+  const goToProfile = useCallback(
+    (userId?: string) => {
+      if (!userId || userId === MOCK_CURRENT_USER.id) {
+        router.push({ pathname: '/profile' });
+        return;
+      }
+
+      router.push({ pathname: '/profile/[id]', params: { id: userId } });
+    },
+    [router],
+  );
+
+  return {
+    goToProfile,
+    currentUser: MOCK_CURRENT_USER,
+    currentUserId: MOCK_CURRENT_USER.id,
+  };
+};


### PR DESCRIPTION
 Descripción del cambio

Se implementó la funcionalidad completa de perfiles de usuario (público y privado) en la app ChangaYa.

Detalles

Se crearon las pantallas:

/perfil/[id].tsx → vista pública de perfil (trabajador o contratante).

/perfil/index.tsx → vista privada del usuario actual.

Se añadieron componentes reutilizables:

ProfileHeader, SkillsList, ReviewItem.

Se agregó useProfileNavigation para manejar de forma centralizada la navegación entre perfiles.

Se actualizó la navegación global:

Desde detalle de changa, chats y tabs se puede acceder al perfil correspondiente (público o privado).

Se unificaron los datos mock:

MOCK_CURRENT_USER (usuario autenticado).

MOCK_PROFILES (trabajadores y contratantes).

 Comportamiento esperado

El usuario actual accede a su propio perfil desde el tab Perfil o tocando su avatar en la home.

Al presionar Ver perfil sobre otro usuario (changa o chat), se abre su perfil público.

La navegación distingue automáticamente entre público y privado según el ID del usuario.

 Pendiente / Próximos pasos

Integrar con Supabase para obtener datos reales.

Habilitar edición del perfil privado.

Reemplazar mocks de reseñas y habilidades por datos dinámicos.